### PR TITLE
fix: BIM-20240 fix scroll visibility change

### DIFF
--- a/projects/kit/src/components/scrollable/components/scrollable/scrollable.component.ts
+++ b/projects/kit/src/components/scrollable/components/scrollable/scrollable.component.ts
@@ -535,20 +535,16 @@ export class ScrollableComponent implements OnInit, AfterViewInit, OnDestroy, On
         this.hasHorizontalScrollbar$.next(hasHorizontalScrollbarCurrent);
 
         const isVerticalScrollbarVisible: boolean =
-          !this.invisibleScrollbars.includes('vertical') && hasVerticalScrollbarCurrent;
+          !this.invisibleScrollbars.includes('vertical') && hasVerticalScrollbarCurrent && hasVerticalScrollbar;
 
         const isHorizontalScrollbarVisible: boolean =
-          !this.invisibleScrollbars.includes('horizontal') && hasHorizontalScrollbarCurrent;
+          !this.invisibleScrollbars.includes('horizontal') && hasHorizontalScrollbarCurrent && hasHorizontalScrollbar;
 
-        if (isVerticalScrollbarVisible !== hasVerticalScrollbar) {
-          this.ngZone.run(() => this.verticalScrollVisibilityChanged.emit(isVerticalScrollbarVisible));
-          this.setScrollbarsClassesByVerticalScrollbarVisibility(isVerticalScrollbarVisible);
-        }
+        this.ngZone.run(() => this.verticalScrollVisibilityChanged.emit(isVerticalScrollbarVisible));
+        this.setScrollbarsClassesByVerticalScrollbarVisibility(isVerticalScrollbarVisible);
 
-        if (isHorizontalScrollbarVisible !== hasHorizontalScrollbar) {
-          this.ngZone.run(() => this.horizontalScrollVisibilityChanged.emit(isHorizontalScrollbarVisible));
-          this.setScrollbarsClassesByHorizontalScrollbarVisibility(isHorizontalScrollbarVisible);
-        }
+        this.ngZone.run(() => this.horizontalScrollVisibilityChanged.emit(isHorizontalScrollbarVisible));
+        this.setScrollbarsClassesByHorizontalScrollbarVisibility(isHorizontalScrollbarVisible);
 
         this.verticalScrollbar.setSizes({
           contentSizePx: contentElement.clientHeight,


### PR DESCRIPTION
Related to [BIM-20240](https://jira.bimeister.io/browse/BIM-20240)

При изменении invisibleScrollbars (horizontal, vertical) - условие isVerticalScrollbarVisible !== hasVerticalScrollbar срабатывало 1 раз, т.к левая часть всегда true, если для данного контейнера может быть применен скролл (и так же для горизонтального).
Не много поменял условие.
