### PR TITLE
Fix/20235

### DIFF
--- a/projects/forms/src/components/input/components/input-number/input-number.component.ts
+++ b/projects/forms/src/components/input/components/input-number/input-number.component.ts
@@ -14,7 +14,7 @@ export class InputNumberComponent extends InputBase<ValueType> {
   public setValue(value: ValueType): void {
     const serializedValue: string = isNil(value) ? '' : String(value);
     const prevValue: ValueType = this.value$.getValue();
-    if (!prevValue) {
+    if (!prevValue || serializedValue) {
       this.value$.next(serializedValue);
     }
   }


### PR DESCRIPTION
Поправил input type=number из-за того, что после того, как вводим точку, input отдает нам пустую строку. В данный момент мы смотрим, есть ли у нас предыдущее значение (prevValue, если кто-то будет сетать начальный стейт в контроле) или новое введенное значение.