### PR TITLE
Добавлена поддержка директивы *pupaOptionActionsRight в компонент select-option-component

### DIFF
--- a/projects/forms/src/components/select/components/select-option/select-option.component.html
+++ b/projects/forms/src/components/select/components/select-option/select-option.component.html
@@ -6,5 +6,6 @@
     [forceResetHover]="isOpened$ | async"
   >
     <ng-content></ng-content>
+    <ng-container *pupaOptionActionsRight [ngTemplateOutlet]="optionActionsRightDirective?.templateRef"></ng-container>
   </pupa-option>
 </div>

--- a/projects/forms/src/components/select/components/select-option/select-option.component.ts
+++ b/projects/forms/src/components/select/components/select-option/select-option.component.ts
@@ -1,7 +1,8 @@
-import { ChangeDetectionStrategy, Component, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ContentChild, Input, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { SelectStateService } from '../../services/select-state.service';
 import { SelectOptionBase } from '../../../../declarations/classes/abstract/select-option-base.abstract';
 import { BehaviorSubject, Subscription } from 'rxjs';
+import { OptionActionsRightDirective } from '@bimeister/pupakit.kit';
 
 @Component({
   selector: 'pupa-select-option',
@@ -11,6 +12,7 @@ import { BehaviorSubject, Subscription } from 'rxjs';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SelectOptionComponent<T> extends SelectOptionBase<T> implements OnDestroy {
+  @ContentChild(OptionActionsRightDirective) public optionActionsRightDirective: OptionActionsRightDirective;
   @Input() public value: T = null;
   @Input() public isDisabled: boolean = false;
   @Input() public hasCheckbox: boolean = false;


### PR DESCRIPTION
Добавлена поддержка директивы *pupaOptionActionsRight в компонент select-option-component для отрисовки элементов с правой стороны option'а. Использует pupa-option, который уже имел этот функционал и соответствующую директиву, но в select-option-component это видимо забыли поддержать.