### PR TITLE
feature: BIM-30686 'TreeEvents.Expand' event payload type has been replaced with the 'FlatTreeItem'.

### DIFF
--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-1/tree-new-example-1.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-1/tree-new-example-1.component.ts
@@ -31,7 +31,9 @@ export class TreeNewExample1Component implements OnDestroy {
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
-      .subscribe((event: TreeEvents.Expand) => this.controller.setChildren(event.payload, this.fetch(event.payload)));
+      .subscribe((event: TreeEvents.Expand) =>
+        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+      );
   }
 
   private removeChildrenOnCollapse(): Subscription {

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-2/tree-new-example-2.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-2/tree-new-example-2.component.ts
@@ -31,7 +31,9 @@ export class TreeNewExample2Component implements OnDestroy {
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
-      .subscribe((event: TreeEvents.Expand) => this.controller.setChildren(event.payload, this.fetch(event.payload)));
+      .subscribe((event: TreeEvents.Expand) =>
+        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+      );
   }
 
   private removeChildrenOnCollapse(): Subscription {

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-3/tree-new-example-3.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-3/tree-new-example-3.component.ts
@@ -34,7 +34,9 @@ export class TreeNewExample3Component implements OnDestroy {
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
-      .subscribe((event: TreeEvents.Expand) => this.controller.setChildren(event.payload, this.fetch(event.payload)));
+      .subscribe((event: TreeEvents.Expand) =>
+        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+      );
   }
 
   private removeChildrenOnCollapse(): Subscription {

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-4/tree-new-example-4.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-4/tree-new-example-4.component.ts
@@ -32,7 +32,9 @@ export class TreeNewExample4Component implements OnDestroy {
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
-      .subscribe((event: TreeEvents.Expand) => this.controller.setChildren(event.payload, this.fetch(event.payload)));
+      .subscribe((event: TreeEvents.Expand) =>
+        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+      );
   }
 
   private removeChildrenOnCollapse(): Subscription {

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-5/tree-new-example-5.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-5/tree-new-example-5.component.ts
@@ -29,10 +29,13 @@ export class TreeNewExample5Component implements OnDestroy {
   public initController(): void {
     this.controller.setChildren(null, this.fetch());
   }
+
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
-      .subscribe((event: TreeEvents.Expand) => this.controller.setChildren(event.payload, this.fetch(event.payload)));
+      .subscribe((event: TreeEvents.Expand) =>
+        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+      );
   }
 
   private removeChildrenOnCollapse(): Subscription {

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-6/tree-new-example-6.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-6/tree-new-example-6.component.ts
@@ -36,7 +36,9 @@ export class TreeNewExample6Component implements OnDestroy {
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
-      .subscribe((event: TreeEvents.Expand) => this.controller.setChildren(event.payload, this.fetch(event.payload)));
+      .subscribe((event: TreeEvents.Expand) =>
+        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+      );
   }
 
   private removeChildrenOnCollapse(): Subscription {

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-7/tree-new-example-7.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-7/tree-new-example-7.component.ts
@@ -45,7 +45,9 @@ export class TreeNewExample7Component implements OnDestroy {
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
-      .subscribe((event: TreeEvents.Expand) => this.controller.setChildren(event.payload, this.fetch(event.payload)));
+      .subscribe((event: TreeEvents.Expand) =>
+        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+      );
   }
 
   private removeChildrenOnCollapse(): Subscription {

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-8/tree-new-example-8.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-8/tree-new-example-8.component.ts
@@ -35,7 +35,9 @@ export class TreeNewExample8Component implements OnDestroy {
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
-      .subscribe((event: TreeEvents.Expand) => this.controller.setChildren(event.payload, this.fetch(event.payload)));
+      .subscribe((event: TreeEvents.Expand) =>
+        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+      );
   }
 
   private removeChildrenOnCollapse(): Subscription {

--- a/projects/tree/src/components/tree-new/components/tree-new/tree-new.component.ts
+++ b/projects/tree/src/components/tree-new/components/tree-new/tree-new.component.ts
@@ -90,15 +90,18 @@ export class TreeNewComponent<T> implements AfterViewInit, OnChanges, OnDestroy 
   public hasDragAndDrop$: Observable<boolean>;
   public trackBy$: Observable<TrackByFunction<FlatTreeItem>>;
   public treeItemSizePx$: Observable<number>;
+  private scrollBehavior$: Observable<ScrollBehavior>;
+  private eventBus: EventBus;
+
   public readonly treeControl: FlatTreeControl<FlatTreeItem> = new FlatTreeControl<FlatTreeItem>(
     TreeNewComponent.getLevel,
     TreeNewComponent.isExpandable
   );
   public readonly listRange$: BehaviorSubject<ListRange> = new BehaviorSubject(null);
   public readonly dragAndDropMeta$: BehaviorSubject<Nullable<DragAndDropMeta>> = new BehaviorSubject(null);
+
   public readonly bufferPx: number = TREE_ITEM_SIZE_PX * ITEM_BUFFER_COUNT;
-  private scrollBehavior$: Observable<ScrollBehavior>;
-  private eventBus: EventBus;
+
   private readonly expandWithDelay$: Subject<Nullable<FlatTreeItem>> = new Subject<Nullable<FlatTreeItem>>();
   private readonly subscription: Subscription = new Subscription();
 
@@ -107,14 +110,6 @@ export class TreeNewComponent<T> implements AfterViewInit, OnChanges, OnDestroy 
     public readonly host: ElementRef<HTMLElement>,
     private readonly changeDetectorRef: ChangeDetectorRef
   ) {}
-
-  private static getLevel(treeItem: FlatTreeItem): number {
-    return treeItem.level;
-  }
-
-  private static isExpandable(treeItem: FlatTreeItem): boolean {
-    return treeItem.isExpandable;
-  }
 
   public ngAfterViewInit(): void {
     this.subscription.add(this.getSubscriptionToSetLoading());
@@ -402,5 +397,13 @@ export class TreeNewComponent<T> implements AfterViewInit, OnChanges, OnDestroy 
     newMeta.dragTreeItemIsDisplayed = true;
 
     this.dragAndDropMeta$.next(newMeta);
+  }
+
+  private static getLevel(treeItem: FlatTreeItem): number {
+    return treeItem.level;
+  }
+
+  private static isExpandable(treeItem: FlatTreeItem): boolean {
+    return treeItem.isExpandable;
   }
 }

--- a/projects/tree/src/components/tree-new/components/tree-new/tree-new.component.ts
+++ b/projects/tree/src/components/tree-new/components/tree-new/tree-new.component.ts
@@ -47,6 +47,7 @@ interface Position {
   top: number;
   left: number;
 }
+
 type ScrollDirection = null | 'up' | 'down';
 
 const EXPAND_WHILE_DRAGGING_DELAY: number = 1000;
@@ -89,18 +90,15 @@ export class TreeNewComponent<T> implements AfterViewInit, OnChanges, OnDestroy 
   public hasDragAndDrop$: Observable<boolean>;
   public trackBy$: Observable<TrackByFunction<FlatTreeItem>>;
   public treeItemSizePx$: Observable<number>;
-  private scrollBehavior$: Observable<ScrollBehavior>;
-  private eventBus: EventBus;
-
   public readonly treeControl: FlatTreeControl<FlatTreeItem> = new FlatTreeControl<FlatTreeItem>(
     TreeNewComponent.getLevel,
     TreeNewComponent.isExpandable
   );
   public readonly listRange$: BehaviorSubject<ListRange> = new BehaviorSubject(null);
   public readonly dragAndDropMeta$: BehaviorSubject<Nullable<DragAndDropMeta>> = new BehaviorSubject(null);
-
   public readonly bufferPx: number = TREE_ITEM_SIZE_PX * ITEM_BUFFER_COUNT;
-
+  private scrollBehavior$: Observable<ScrollBehavior>;
+  private eventBus: EventBus;
   private readonly expandWithDelay$: Subject<Nullable<FlatTreeItem>> = new Subject<Nullable<FlatTreeItem>>();
   private readonly subscription: Subscription = new Subscription();
 
@@ -109,6 +107,14 @@ export class TreeNewComponent<T> implements AfterViewInit, OnChanges, OnDestroy 
     public readonly host: ElementRef<HTMLElement>,
     private readonly changeDetectorRef: ChangeDetectorRef
   ) {}
+
+  private static getLevel(treeItem: FlatTreeItem): number {
+    return treeItem.level;
+  }
+
+  private static isExpandable(treeItem: FlatTreeItem): boolean {
+    return treeItem.isExpandable;
+  }
 
   public ngAfterViewInit(): void {
     this.subscription.add(this.getSubscriptionToSetLoading());
@@ -259,7 +265,7 @@ export class TreeNewComponent<T> implements AfterViewInit, OnChanges, OnDestroy 
   }
 
   private expandClick(treeItem: FlatTreeItem): void {
-    this.controller.expand(treeItem.id);
+    this.controller.expand(treeItem);
   }
 
   private collapseClick(treeItem: FlatTreeItem): void {
@@ -396,13 +402,5 @@ export class TreeNewComponent<T> implements AfterViewInit, OnChanges, OnDestroy 
     newMeta.dragTreeItemIsDisplayed = true;
 
     this.dragAndDropMeta$.next(newMeta);
-  }
-
-  private static getLevel(treeItem: FlatTreeItem): number {
-    return treeItem.level;
-  }
-
-  private static isExpandable(treeItem: FlatTreeItem): boolean {
-    return treeItem.isExpandable;
   }
 }

--- a/projects/tree/src/declarations/classes/tree-controller.class.ts
+++ b/projects/tree/src/declarations/classes/tree-controller.class.ts
@@ -28,11 +28,6 @@ export class TreeController {
     this.setTreeItemSizePx(options?.treeItemSizePx);
   }
 
-  protected dispatchInQueue(event: TreeEvents.TreeEventBase): void {
-    const queueEvent: QueueEvents.AddToQueue = new QueueEvents.AddToQueue(event);
-    this.eventBus.dispatch(queueEvent);
-  }
-
   public getOptions(): Nullable<TreeControllerOptions> {
     return this.options;
   }
@@ -61,8 +56,8 @@ export class TreeController {
     return this.dataDisplayCollection;
   }
 
-  public expand(treeItemId: string): void {
-    this.eventBus.dispatch(new TreeEvents.Expand(treeItemId));
+  public expand(treeItem: FlatTreeItem): void {
+    this.eventBus.dispatch(new TreeEvents.Expand(treeItem));
   }
 
   public setChildren(treeItemId: string, children: FlatTreeItem[]): void {
@@ -87,6 +82,11 @@ export class TreeController {
 
   public scrollTop(scrollTopPx: number): void {
     this.dispatchInQueue(new TreeEvents.ScrollTop(scrollTopPx));
+  }
+
+  protected dispatchInQueue(event: TreeEvents.TreeEventBase): void {
+    const queueEvent: QueueEvents.AddToQueue = new QueueEvents.AddToQueue(event);
+    this.eventBus.dispatch(queueEvent);
   }
 
   private setScrollBehavior(scrollBehavior: ScrollBehavior = 'smooth'): void {

--- a/projects/tree/src/declarations/classes/tree-controller.class.ts
+++ b/projects/tree/src/declarations/classes/tree-controller.class.ts
@@ -28,6 +28,11 @@ export class TreeController {
     this.setTreeItemSizePx(options?.treeItemSizePx);
   }
 
+  protected dispatchInQueue(event: TreeEvents.TreeEventBase): void {
+    const queueEvent: QueueEvents.AddToQueue = new QueueEvents.AddToQueue(event);
+    this.eventBus.dispatch(queueEvent);
+  }
+
   public getOptions(): Nullable<TreeControllerOptions> {
     return this.options;
   }
@@ -82,11 +87,6 @@ export class TreeController {
 
   public scrollTop(scrollTopPx: number): void {
     this.dispatchInQueue(new TreeEvents.ScrollTop(scrollTopPx));
-  }
-
-  protected dispatchInQueue(event: TreeEvents.TreeEventBase): void {
-    const queueEvent: QueueEvents.AddToQueue = new QueueEvents.AddToQueue(event);
-    this.eventBus.dispatch(queueEvent);
   }
 
   private setScrollBehavior(scrollBehavior: ScrollBehavior = 'smooth'): void {

--- a/projects/tree/src/declarations/events/tree.events.ts
+++ b/projects/tree/src/declarations/events/tree.events.ts
@@ -20,21 +20,36 @@ export namespace TreeEvents {
   }
 
   export class Click extends TreeEventBase<FlatTreeItem> {}
+
   export class RemoveItem extends TreeEventBase<string> {}
+
   export class UpdateItem extends TreeEventBase<FlatTreeItem> {}
+
   export class ScrollById extends TreeEventBase<string> {}
+
   export class Drop extends TreeEventBase<DropEventInterface<FlatTreeItem>> {}
+
   export class ScrollByIndex extends TreeEventBase<number> {}
 
   export class ScrollTop extends TreeEventBase<number> {}
+
   export class ScrollViewport extends TreeEventBase<number> {}
+
   export class SetData extends TreeEventBase<FlatTreeItem[]> {}
+
   export class SetLoading extends TreeEventBase<boolean> {}
+
   export class SetSelected extends TreeEventBase<string[]> {}
+
   export class Collapse extends TreeEventBase<string> {}
-  export class Expand extends TreeEventBase<string> {}
+
+  export class Expand extends TreeEventBase<FlatTreeItem> {}
+
   export class ExpandWhileDragging extends TreeEventBase<string> {}
+
   export class RemoveChildren extends TreeEventBase<string> {}
+
   export class SetExpanded extends TreeEventBase<string[]> {}
+
   export class SetChildren extends TreeEventBase<SetChildrenEventPayload> {}
 }


### PR DESCRIPTION
Для события `TreeEvents.Exapnd` был изменён тип у `payload` со `string` на `FlatTreeItem`. Связанный [MR](https://git.bimeister.io/bimeister/bimeister/-/merge_requests/8542) в продукт мёржить только после этого.