### PR TITLE
Bugfix/bim 34561 scene tree duplicates

### DIFF
--- a/projects/demo/src/app/pages/resizer-demo/examples/example-1/example-1.component.ts
+++ b/projects/demo/src/app/pages/resizer-demo/examples/example-1/example-1.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ViewEncapsulation, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { FlatTreeItem, TreeController, TreeEvents } from '@bimeister/pupakit.tree';
 import { Subscription } from 'rxjs';
 import { DATA as treeData } from '../../../tree-new-demo/examples/example-tree.data';
@@ -78,14 +78,14 @@ export class ResizerDemoExample1Component implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/demo/src/app/pages/resizer-demo/examples/example-2/example-2.component.ts
+++ b/projects/demo/src/app/pages/resizer-demo/examples/example-2/example-2.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ViewEncapsulation, OnDestroy } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { FlatTreeItem, TreeController, TreeEvents } from '@bimeister/pupakit.tree';
 import { Subscription } from 'rxjs';
 import { DATA as treeData } from '../../../tree-new-demo/examples/example-tree.data';
@@ -78,14 +78,14 @@ export class ResizerDemoExample2Component implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/demo/src/app/pages/resizer-demo/resizer-demo.component.ts
+++ b/projects/demo/src/app/pages/resizer-demo/resizer-demo.component.ts
@@ -129,7 +129,7 @@ export class ResizerDemoComponent implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   public showThresholdReached(): void {
@@ -159,7 +159,7 @@ export class ResizerDemoComponent implements OnDestroy {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/demo/src/app/pages/tree-new-demo/data/tree-controller-declarations.data.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/data/tree-controller-declarations.data.ts
@@ -34,7 +34,7 @@ export class TreeController {
   public addChildren(treeItemId: string, children: FlatTreeItem[]): void
 
   /*
-   Uses to add children to the selected tree item with purging previously set children.
+   Uses to add children to the selected tree item with preventing adding previously added children.
    Input parameters are the ID of the selected tree item and an array of children.
   */
   public resetChildren(treeItemId: string, children: FlatTreeItem[]): void

--- a/projects/demo/src/app/pages/tree-new-demo/data/tree-controller-declarations.data.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/data/tree-controller-declarations.data.ts
@@ -28,10 +28,16 @@ export class TreeController {
   public getDataDisplayCollectionRef(): TreeDataDisplayCollectionRef
 
   /*
-   Uses to set children of the selected tree item.
+   Uses to add children to the selected tree item.
    Input parameters are the ID of the selected tree item and an array of children.
   */
-  public setChildren(treeItemId: string, children: FlatTreeItem[]): void
+  public addChildren(treeItemId: string, children: FlatTreeItem[]): void
+
+  /*
+   Uses to add children to the selected tree item with purging previously set children.
+   Input parameters are the ID of the selected tree item and an array of children.
+  */
+  public resetChildren(treeItemId: string, children: FlatTreeItem[]): void
 
   /*
    Uses to remove children from the selected tree item.

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-1/tree-new-example-1.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-1/tree-new-example-1.component.ts
@@ -25,14 +25,14 @@ export class TreeNewExample1Component implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-2/tree-new-example-2.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-2/tree-new-example-2.component.ts
@@ -25,14 +25,14 @@ export class TreeNewExample2Component implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-3/tree-new-example-3.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-3/tree-new-example-3.component.ts
@@ -28,14 +28,14 @@ export class TreeNewExample3Component implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-4/tree-new-example-4.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-4/tree-new-example-4.component.ts
@@ -26,14 +26,14 @@ export class TreeNewExample4Component implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-5/tree-new-example-5.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-5/tree-new-example-5.component.ts
@@ -27,14 +27,14 @@ export class TreeNewExample5Component implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   private setChildrenOnExpand(): Subscription {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-6/tree-new-example-6.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-6/tree-new-example-6.component.ts
@@ -26,7 +26,7 @@ export class TreeNewExample6Component implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   public setLoading(isLoading: boolean): void {
@@ -37,7 +37,7 @@ export class TreeNewExample6Component implements OnDestroy {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-7/tree-new-example-7.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-7/tree-new-example-7.component.ts
@@ -27,7 +27,7 @@ export class TreeNewExample7Component implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   public scrollToTreeNode(): void {
@@ -46,7 +46,7 @@ export class TreeNewExample7Component implements OnDestroy {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/demo/src/app/pages/tree-new-demo/examples/example-8/tree-new-example-8.component.ts
+++ b/projects/demo/src/app/pages/tree-new-demo/examples/example-8/tree-new-example-8.component.ts
@@ -25,7 +25,7 @@ export class TreeNewExample8Component implements OnDestroy {
   }
 
   public initController(): void {
-    this.controller.setChildren(null, this.fetch());
+    this.controller.addChildren(null, this.fetch());
   }
 
   public removeTreeItem(item: FlatTreeItem): void {
@@ -36,7 +36,7 @@ export class TreeNewExample8Component implements OnDestroy {
     return this.controller
       .getEvents(TreeEvents.Expand)
       .subscribe((event: TreeEvents.Expand) =>
-        this.controller.setChildren(event.payload.id, this.fetch(event.payload.id))
+        this.controller.addChildren(event.payload.id, this.fetch(event.payload.id))
       );
   }
 

--- a/projects/tree/src/declarations/classes/default-tree-event-handler.class.ts
+++ b/projects/tree/src/declarations/classes/default-tree-event-handler.class.ts
@@ -147,7 +147,12 @@ export class DefaultTreeEventHandler {
     data: FlatTreeItem[],
     expandedIdsList: string[]
   ): void {
-    const [dataWithChildren, newExpandedList] = this.getAddedChildren(parentId, children, data, expandedIdsList);
+    const [dataWithChildren, newExpandedList]: [FlatTreeItem[], string[]] = this.getAddedChildren(
+      parentId,
+      children,
+      data,
+      expandedIdsList
+    );
     if (isEmpty(dataWithChildren) && isEmpty(newExpandedList)) {
       return;
     }
@@ -161,7 +166,13 @@ export class DefaultTreeEventHandler {
     data: FlatTreeItem[],
     expandedIdsList: string[]
   ): void {
-    const [newData, expandedIds] = this.getAddedChildren(parentId, children, data, expandedIdsList, true);
+    const [newData, expandedIds]: [FlatTreeItem[], string[]] = this.getAddedChildren(
+      parentId,
+      children,
+      data,
+      expandedIdsList,
+      true
+    );
     if (isEmpty(newData) && isEmpty(expandedIds)) {
       return;
     }
@@ -173,7 +184,7 @@ export class DefaultTreeEventHandler {
     const [dataWithoutChildren, expandedWithoutChildren]: [FlatTreeItem[], string[]] = this.getRemovedChildren(
       parentId,
       data,
-      expanded
+      expandedIds
     );
     this.eventBus.dispatch(new TreeEvents.SetData(dataWithoutChildren));
     this.eventBus.dispatch(new TreeEvents.SetExpanded(expandedWithoutChildren));
@@ -183,13 +194,13 @@ export class DefaultTreeEventHandler {
     const treeItemExists: boolean = DefaultTreeEventHandler.treeItemExists(removeItemId, data);
     if (!treeItemExists) {
       this.eventBus.dispatch(new TreeEvents.SetData(data));
-      this.eventBus.dispatch(new TreeEvents.SetExpanded(expanded));
+      this.eventBus.dispatch(new TreeEvents.SetExpanded(expandedIds));
       return;
     }
     const [dataWithoutChildren, expandedWithoutChildren]: [FlatTreeItem[], string[]] = this.getRemovedChildren(
       removeItemId,
       data,
-      expanded
+      expandedIds
     );
     const dataWithoutRemovedItem: FlatTreeItem[] = dataWithoutChildren.filter(
       (treeItem: FlatTreeItem) => treeItem.id !== removeItemId
@@ -271,7 +282,7 @@ export class DefaultTreeEventHandler {
     const nextNonChildIndex: number = dataAfterParent.findIndex(
       (dataItem: FlatTreeItem) => dataItem.level <= parent.level
     );
-    return dataAfterParent.slice(0, nextNonChildIndex);
+    return dataAfterParent.slice(0, nextNonChildIndex === -1 ? dataAfterParent.length : nextNonChildIndex);
   }
 
   private getRemovedChildren(parentId: string, data: FlatTreeItem[], expanded: string[]): [FlatTreeItem[], string[]] {

--- a/projects/tree/src/declarations/classes/default-tree-event-handler.class.ts
+++ b/projects/tree/src/declarations/classes/default-tree-event-handler.class.ts
@@ -179,7 +179,7 @@ export class DefaultTreeEventHandler {
     this.eventBus.dispatch(new TreeEvents.SetExpanded(expandedWithoutChildren));
   }
 
-  private removeItemWithChildren(removeItemId: string, data: FlatTreeItem[], expanded: string[]): void {
+  private removeItemWithChildren(removeItemId: string, data: FlatTreeItem[], expandedIds: string[]): void {
     const treeItemExists: boolean = DefaultTreeEventHandler.treeItemExists(removeItemId, data);
     if (!treeItemExists) {
       this.eventBus.dispatch(new TreeEvents.SetData(data));

--- a/projects/tree/src/declarations/classes/default-tree-event-handler.class.ts
+++ b/projects/tree/src/declarations/classes/default-tree-event-handler.class.ts
@@ -169,7 +169,7 @@ export class DefaultTreeEventHandler {
     this.eventBus.dispatch(new TreeEvents.SetExpanded(expandedIds));
   }
 
-  private removeChildren(parentId: string, data: FlatTreeItem[], expanded: string[]): void {
+  private removeChildren(parentId: string, data: FlatTreeItem[], expandedIds: string[]): void {
     const [dataWithoutChildren, expandedWithoutChildren]: [FlatTreeItem[], string[]] = this.getRemovedChildren(
       parentId,
       data,

--- a/projects/tree/src/declarations/classes/tree-controller.class.ts
+++ b/projects/tree/src/declarations/classes/tree-controller.class.ts
@@ -65,8 +65,12 @@ export class TreeController {
     this.eventBus.dispatch(new TreeEvents.Expand(treeItem));
   }
 
-  public setChildren(treeItemId: string, children: FlatTreeItem[]): void {
-    this.dispatchInQueue(new TreeEvents.SetChildren({ treeItemId, children }));
+  public addChildren(treeItemId: string, children: FlatTreeItem[]): void {
+    this.dispatchInQueue(new TreeEvents.AddChildren({ treeItemId, children }));
+  }
+
+  public resetChildren(treeItemId: string, children: FlatTreeItem[]): void {
+    this.dispatchInQueue(new TreeEvents.ResetChildren({ treeItemId, children }));
   }
 
   public removeChildren(treeItemId: string): void {

--- a/projects/tree/src/declarations/events/tree.events.ts
+++ b/projects/tree/src/declarations/events/tree.events.ts
@@ -47,9 +47,11 @@ export namespace TreeEvents {
 
   export class ExpandWhileDragging extends TreeEventBase<string> {}
 
-  export class RemoveChildren extends TreeEventBase<string> {}
-
   export class SetExpanded extends TreeEventBase<string[]> {}
 
-  export class SetChildren extends TreeEventBase<SetChildrenEventPayload> {}
+  export class AddChildren extends TreeEventBase<SetChildrenEventPayload> {}
+
+  export class ResetChildren extends TreeEventBase<SetChildrenEventPayload> {}
+
+  export class RemoveChildren extends TreeEventBase<string> {}
 }


### PR DESCRIPTION
New `resetChildren` method has been added to the `TreeController`. `setChildren` method has been renamed into the `addChildren`.