### PR TITLE
fix: BIM-36195 changed radio directives

### DIFF
--- a/projects/demo/src/app/pages/radio-button-demo/examples/example-6/example-6.component.html
+++ b/projects/demo/src/app/pages/radio-button-demo/examples/example-6/example-6.component.html
@@ -4,8 +4,6 @@
       <pupa-radio-image-control class="radio-control" [value]="1">
         <span>Option 1</span>
 
-        <pupa-icon class="icon" *pupaRadioIcon [name]="'app-help-filled'"></pupa-icon>
-
         <img class="image" *pupaRadioImage alt="" [src]="'assets/radio-image.svg'" />
       </pupa-radio-image-control>
 
@@ -20,7 +18,7 @@
       <pupa-radio-image-control class="radio-control" [value]="3">
         <span>Option 3</span>
 
-        <pupa-icon class="icon" *pupaRadioIcon [name]="'app-help-filled'"></pupa-icon>
+        <pupa-icon class="icon" *pupaRadioIcon [pupaTooltip]="'Tooltip'" [name]="'app-help-filled'"></pupa-icon>
 
         <img class="image" *pupaRadioImage alt="" [src]="'assets/radio-image.svg'" />
       </pupa-radio-image-control>

--- a/projects/forms/src/components/radio-group/directives/radio-icon.directive.ts
+++ b/projects/forms/src/components/radio-group/directives/radio-icon.directive.ts
@@ -1,10 +1,8 @@
-import { Directive, Input, TemplateRef } from '@angular/core';
+import { Directive, TemplateRef } from '@angular/core';
 
 @Directive({
   selector: '[pupaRadioIcon]',
 })
 export class RadioIconDirective {
-  @Input() public pupaRadioIcon: boolean;
-
   constructor(public readonly templateRef: TemplateRef<unknown>) {}
 }

--- a/projects/forms/src/components/radio-group/directives/radio-image.directive.ts
+++ b/projects/forms/src/components/radio-group/directives/radio-image.directive.ts
@@ -1,10 +1,8 @@
-import { Directive, Input, TemplateRef } from '@angular/core';
+import { Directive, TemplateRef } from '@angular/core';
 
 @Directive({
   selector: '[pupaRadioImage]',
 })
 export class RadioImageDirective {
-  @Input() public pupaRadioImage: boolean;
-
   constructor(public readonly templateRef: TemplateRef<unknown>) {}
 }


### PR DESCRIPTION
Данный фикс был сделан, чтобы в основном проекте не указывать такие вещи: *pupaRadioIcon="true" или *pupaRadioImage="true"
![image](https://github.com/bimeister/pupakit/assets/52610416/b77edb03-e2e6-4853-bfdd-6514fc9be241)
