### PR TITLE
feature: BIM-44508 loader style update

### DIFF
--- a/projects/common/src/declarations/types/loader-kind.type.ts
+++ b/projects/common/src/declarations/types/loader-kind.type.ts
@@ -1,1 +1,1 @@
-export type LoaderKind = 'neutral' | 'success' | 'warning' | 'danger';
+export type LoaderKind = 'default' | 'success' | 'warning' | 'danger';

--- a/projects/demo/src/app/pages/loader-demo/examples/demo-loader/demo-loader.component.html
+++ b/projects/demo/src/app/pages/loader-demo/examples/demo-loader/demo-loader.component.html
@@ -1,1 +1,5 @@
-<pupa-loader size="50px"></pupa-loader>
+<div class="loader-container">
+  <pupa-loader size="50px"></pupa-loader>
+  <pupa-loader size="50px" type="determinate" [progress]="50"></pupa-loader>
+  <pupa-loader size="50px" type="determinate" [isError]="true" errorText="Loader error text"></pupa-loader>
+</div>

--- a/projects/demo/src/app/pages/loader-demo/examples/demo-loader/demo-loader.component.scss
+++ b/projects/demo/src/app/pages/loader-demo/examples/demo-loader/demo-loader.component.scss
@@ -1,0 +1,6 @@
+.loader-container {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 4rem 0;
+  gap: 4rem;
+}

--- a/projects/demo/src/app/pages/loader-demo/examples/demo-loader/demo-loader.component.ts
+++ b/projects/demo/src/app/pages/loader-demo/examples/demo-loader/demo-loader.component.ts
@@ -2,6 +2,7 @@ import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/
 
 @Component({
   selector: 'demo-loader',
+  styleUrls: ['demo-loader.component.scss'],
   templateUrl: './demo-loader.component.html',
   encapsulation: ViewEncapsulation.Emulated,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/demo/src/app/pages/loader-demo/loader-demo.component.html
+++ b/projects/demo/src/app/pages/loader-demo/loader-demo.component.html
@@ -3,6 +3,13 @@
 <demo-page>
   <div *demoPageTab="'overview'">
     <h3 demoAnchor>Loader</h3>
+    <pupa-callout>
+      The <pupa-code-inline>loader</pupa-code-inline> supports two types: "determinate" and "indeterminate". In the
+      "determinate" mode, the progress is set via the <pupa-code-inline>progress</pupa-code-inline> property, which can
+      be a whole number between 0 and 100. Also in this mode you can cause an error condition and set the text of the
+      tooltip. The default type is "indeterminate".
+    </pupa-callout>
+
     <pupa-code-container [content]="loaderExampleContent">
       <demo-loader *pupaCodeContainerPreviewTemplate></demo-loader>
     </pupa-code-container>

--- a/projects/demo/src/app/pages/loader-demo/loader-demo.component.ts
+++ b/projects/demo/src/app/pages/loader-demo/loader-demo.component.ts
@@ -12,7 +12,7 @@ const BASE_EXAMPLE_URL: string = 'loader-demo/examples';
 })
 export class LoaderDemoComponent {
   public readonly typeFormControl: FormControl<Loader> = new FormControl<Loader>('determinate');
-  public readonly kindFormControl: FormControl<LoaderKind> = new FormControl<LoaderKind>('neutral');
+  public readonly kindFormControl: FormControl<LoaderKind> = new FormControl<LoaderKind>('default');
   public readonly sizeFormControl: FormControl<number | null> = new FormControl<number | null>(50);
   public readonly progressFormControl: FormControl<number | null> = new FormControl<number | null>(50, [
     Validators.required,
@@ -38,8 +38,8 @@ export class LoaderDemoComponent {
 
   public readonly kindOptions: PropsOption[] = [
     {
-      caption: 'neutral',
-      value: 'neutral',
+      caption: 'default',
+      value: 'default',
       isDefault: true,
     },
     {
@@ -58,6 +58,7 @@ export class LoaderDemoComponent {
 
   public readonly loaderExampleContent: Record<string, string> = {
     HTML: `${BASE_EXAMPLE_URL}/demo-loader/demo-loader.component.html`,
+    SCSS: `${BASE_EXAMPLE_URL}/demo-loader/demo-loader.component.scss`,
   };
   public readonly loaderOldExampleContent: Record<string, string> = {
     HTML: `${BASE_EXAMPLE_URL}/demo-loader-old/demo-loader-old.component.html`,

--- a/projects/kit/src/components/loader/components/loader/loader.component.html
+++ b/projects/kit/src/components/loader/components/loader/loader.component.html
@@ -29,22 +29,21 @@
       class="loader__indeterminate-icon"
       [ngClass]="kindClassName"
       focusable="false"
-      viewBox="0 0 30 30"
+      viewBox="0 0 24 24"
     >
-      <circle class="loader__indeterminate-icon_background" [attr.r]="radius" cx="15" cy="15"></circle>
-      <circle class="loader__indeterminate-icon_scale" [attr.r]="radius" cx="15" cy="15"></circle>
+      <circle class="loader__indeterminate-icon_scale" [attr.r]="radius" cx="12" cy="12"></circle>
     </svg>
   </div>
 
   <ng-template #determinateLoader>
-    <svg class="loader__determinate-icon" focusable="false" viewBox="0 0 30 30" *ngIf="!isError; else error">
-      <circle class="loader__determinate-icon_background" [attr.r]="radius" cx="15" cy="15"></circle>
+    <svg class="loader__determinate-icon" focusable="false" viewBox="0 0 24 24" *ngIf="!isError; else error">
+      <circle class="loader__determinate-icon_background" [attr.r]="radius" cx="12" cy="12"></circle>
       <circle
         class="loader__determinate-icon_scale"
         [class.loader__determinate-icon_success]="progress === 100"
         [attr.r]="radius"
-        cx="15"
-        cy="15"
+        cx="12"
+        cy="12"
         [style.stroke-dasharray]="determinateDasharray"
         [style.stroke-dashoffset]="determinateDashOffset"
       ></circle>

--- a/projects/kit/src/components/loader/components/loader/loader.component.scss
+++ b/projects/kit/src/components/loader/components/loader/loader.component.scss
@@ -25,7 +25,8 @@
     height: 100%;
     width: 100%;
     fill: none;
-    stroke-width: 4px;
+    stroke-width: 2px;
+    stroke-linecap: round;
     stroke: currentColor;
 
     &_background {
@@ -51,11 +52,11 @@
     animation: 0.86s cubic-bezier(0.4, 0.15, 0.6, 0.85) infinite rotate;
 
     &_scale {
-      stroke-dasharray: 75px;
-      stroke-dashoffset: 50px;
+      stroke-dasharray: 80px;
+      stroke-dashoffset: 65px;
     }
 
-    &_neutral {
+    &_default {
       color: inherit;
     }
 

--- a/projects/kit/src/components/loader/components/loader/loader.component.ts
+++ b/projects/kit/src/components/loader/components/loader/loader.component.ts
@@ -3,7 +3,7 @@ import { ComponentChanges, Loader, LoaderKind } from '@bimeister/pupakit.common'
 import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 
-const DEFAULT_RADIUS: number = 12;
+const DEFAULT_RADIUS: number = 10;
 
 @Component({
   selector: 'pupa-loader',
@@ -18,8 +18,8 @@ export class LoaderComponent implements OnChanges {
   @Input() public type: Loader = 'indeterminate';
   public readonly type$: BehaviorSubject<Loader> = new BehaviorSubject<Loader>('indeterminate');
 
-  @Input() public kind: LoaderKind = 'neutral';
-  public readonly kind$: BehaviorSubject<LoaderKind> = new BehaviorSubject<LoaderKind>('neutral');
+  @Input() public kind: LoaderKind = 'default';
+  public readonly kind$: BehaviorSubject<LoaderKind> = new BehaviorSubject<LoaderKind>('default');
 
   @Input() public progress: number = 0;
   public readonly progress$: BehaviorSubject<number> = new BehaviorSubject<number>(0);


### PR DESCRIPTION
Related to [BIM-44508](https://jira.bimeister.io/browse/BIM-44508) 

Обновление стилей для `pupa-loader`

![1](https://github.com/bimeister/pupakit/assets/128481706/82d590a8-e97e-4ff3-b565-877b2f0dcfee)