### PR TITLE
fix: BIM-45236 higlighter values typo fix

### DIFF
--- a/projects/common/src/assets/configs/semantic-colors-config.json
+++ b/projects/common/src/assets/configs/semantic-colors-config.json
@@ -670,14 +670,14 @@
           "alpha": "alpha-1000"
         },
         "darkColor": {
-          "color": "neutral-400",
+          "color": "neutral-500",
           "alpha": "alpha-1000"
         }
       },
       {
         "name": "Search",
         "lightColor": {
-          "color": "index-yellow-500",
+          "color": "index-yellow-200",
           "alpha": "alpha-1000"
         },
         "darkColor": {


### PR DESCRIPTION
Related to [BIM-45236](https://jira.bimeister.io/browse/BIM-45236)

Выставлены корректные значения colors для группы цветов **Highlighter** в соответствии с дизайном

![image](https://github.com/bimeister/pupakit/assets/128481706/3bbe3613-2f0e-42e2-ba5f-b7da4d5af3db)
